### PR TITLE
upgrade gleam_stdlib to 0.56.0

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,7 +13,8 @@ repository = { type = "github", user = "gastonche", repo = "gleam_md" }
 # https://gleam.run/writing-gleam/gleam-toml/. 
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = ">= 0.56.0 and < 1.0.0"
+gleam_regexp = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "gleam_regexp", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "7F5E0C0BBEB3C58E57C9CB05FA9002F970C85AD4A63BA1E55CBCB35C15809179" },
+  { name = "gleam_stdlib", version = "0.56.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "7C5169F4DA62BB5CD1FC3EBE40C63415FDE1AAA7E5BD13F2B047FF973B571568" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_regexp = { version = ">= 1.1.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.56.0 and < 1.0.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/render_md.gleam
+++ b/src/render_md.gleam
@@ -8,11 +8,11 @@ import gleam/int
 import gleam/io
 import gleam/list
 import gleam/option.{None, Some}
-import gleam/regex.{type Match}
+import gleam/regexp.{type Match}
 import gleam/result
 import gleam/string
 
-const regex_options = regex.Options(case_insensitive: True, multi_line: True)
+const regex_options = regexp.Options(case_insensitive: True, multi_line: True)
 
 ///
 /// Options that can be used with `render_with_options`
@@ -53,8 +53,8 @@ pub fn render_with_options(markdown: String, options: Options) {
   |> parse_paragraphs(options)
 }
 
-fn to_regex(r: String, options, default: a, next: fn(regex.Regex) -> a) {
-  case regex.compile(r, options) {
+fn to_regex(r: String, options, default: a, next: fn(regexp.Regexp) -> a) {
+  case regexp.compile(r, options) {
     Ok(exp) -> next(exp)
     Error(e) -> {
       io.println_error(e.error)
@@ -66,10 +66,10 @@ fn to_regex(r: String, options, default: a, next: fn(regex.Regex) -> a) {
 fn replace_all(
   text: String,
   r: String,
-  get_replacement: fn(List(regex.Match)) -> String,
+  get_replacement: fn(List(regexp.Match)) -> String,
 ) {
   use exp <- to_regex(r, regex_options, text)
-  regex.scan(exp, text)
+  regexp.scan(exp, text)
   |> get_replacement
 }
 
@@ -77,7 +77,7 @@ fn replace(text: String, r: String, get_replacement: fn(List(String)) -> String)
   replace_all(text, r, list.fold(
     _,
     text,
-    fn(acc, match: regex.Match) {
+    fn(acc, match: regexp.Match) {
       string.replace(
         acc,
         match.content,
@@ -258,10 +258,10 @@ fn parse_list(text: String, options: Options) {
 
   use exp <- to_regex(
     "^(?:\\s*)[*+-]\\s",
-    regex.Options(case_insensitive: True, multi_line: False),
+    regexp.Options(case_insensitive: True, multi_line: False),
     text,
   )
-  let tag = case regex.check(exp, text) {
+  let tag = case regexp.check(exp, text) {
     True -> "ul"
     False -> "ol"
   }


### PR DESCRIPTION
replace deprecated dependency gleam/regex with drop-in replacement gleam_regexp